### PR TITLE
Add Windows control center dashboard

### DIFF
--- a/codex-control-center/README.md
+++ b/codex-control-center/README.md
@@ -1,0 +1,46 @@
+# Codex Control Center
+
+Codex 메인 오케스트레이터, helper 스레드, LLM 웹 스레드, handoff 메시지 흐름, watchdog/중앙 스케줄러 상태를 한 화면에서 볼 수 있는 Windows용 로컬 관제 UI입니다.
+
+## 특징
+
+- 메인 오케스트레이터와 helper 역할 한눈에 보기
+- ChatGPT/Gemini 웹 스레드 레지스트리 표시
+- 최근 handoff 메시지와 helper 응답 흐름 추적
+- watchdog, 중앙 스케줄러, helper queue, Gmail 채널 상태 요약
+- 5초 자동 새로고침
+- 별도 패키지 설치 없이 Python 표준 라이브러리만 사용
+
+## 실행
+
+PowerShell:
+
+```powershell
+Set-Location .\codex-control-center
+.\start_control_center.ps1
+```
+
+또는 `launch_control_center.cmd`를 더블클릭하세요.
+
+기본 주소:
+
+- [http://127.0.0.1:8787](http://127.0.0.1:8787)
+
+## 데이터 소스
+
+앱은 아래 두 레이아웃 중 현재 저장소에 존재하는 런타임 루트를 자동 선택합니다.
+
+- `00_Codex_도구/03_로컬_에이전트_런타임`
+- `03_로컬_에이전트_런타임`
+
+주요 입력 파일:
+
+- `config/codex_helper_thread_roster.json`
+- `config/llm_thread_registry.json`
+- `state/helper_handoffs/status.json`
+- `state/central_scheduler/status.json`
+- `state/turn_continuation_watchdog/status.json`
+
+## GitHub 메모
+
+현재 `origin`은 이미 연결돼 있습니다. 다만 GitHub Project 보드 자동 생성은 API 인증 상태에 따라 추가 조정이 필요할 수 있습니다. 저장소 push는 일반 `git push`로 시도할 수 있습니다.

--- a/codex-control-center/launch_control_center.cmd
+++ b/codex-control-center/launch_control_center.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0start_control_center.ps1"
+endlocal

--- a/codex-control-center/src/control_center_server.py
+++ b/codex-control-center/src/control_center_server.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def read_text_with_fallback(path: Path) -> str:
+    for encoding in ("utf-8-sig", "utf-8", "cp949"):
+        try:
+            return path.read_text(encoding=encoding)
+        except UnicodeDecodeError:
+            continue
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(read_text_with_fallback(path))
+    except Exception:
+        return default
+
+
+def trim_text(value: str | None, limit: int = 300) -> str:
+    if not value:
+        return ""
+    compact = " ".join(str(value).split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1] + "…"
+
+
+def parse_timestamp(value: str | None) -> float:
+    if not value:
+        return 0.0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def safe_get(mapping: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    current: Any = mapping
+    for key in keys:
+        if not isinstance(current, dict):
+            return default
+        current = current.get(key)
+    return current if current is not None else default
+
+
+@dataclass
+class RuntimePaths:
+    repo_root: Path
+    runtime_root: Path
+    state_root: Path
+    config_root: Path
+    helper_handoff_inbox: Path
+
+    @classmethod
+    def detect(cls, explicit_runtime_root: str | None) -> "RuntimePaths":
+        current = Path(__file__).resolve()
+        repo_root = current.parents[2]
+        if explicit_runtime_root:
+            runtime_root = Path(explicit_runtime_root).resolve()
+        else:
+            candidates = [
+                repo_root / "00_Codex_도구" / "03_로컬_에이전트_런타임",
+                repo_root / "03_로컬_에이전트_런타임",
+            ]
+            runtime_root = next((path for path in candidates if path.exists()), candidates[0])
+        return cls(
+            repo_root=repo_root,
+            runtime_root=runtime_root,
+            state_root=runtime_root / "state",
+            config_root=runtime_root / "config",
+            helper_handoff_inbox=runtime_root / "state" / "helper_handoffs" / "inbox",
+        )
+
+
+class SnapshotBuilder:
+    def __init__(self, paths: RuntimePaths) -> None:
+        self.paths = paths
+
+    def build(self) -> dict[str, Any]:
+        roster = read_json(self.paths.config_root / "codex_helper_thread_roster.json", {})
+        registry = read_json(self.paths.config_root / "llm_thread_registry.json", {})
+        helper_status = read_json(self.paths.state_root / "helper_handoffs" / "status.json", {})
+        scheduler_status = read_json(self.paths.state_root / "central_scheduler" / "status.json", {})
+        watchdog_status = read_json(
+            self.paths.state_root / "turn_continuation_watchdog" / "status.json", {}
+        )
+        gmail_status = read_json(self.paths.state_root / "gmail_command_channel_status.json", {})
+
+        helper_by_title = {
+            thread.get("title"): thread for thread in roster.get("threads", []) if thread.get("title")
+        }
+        helper_by_responsibility = {
+            thread.get("responsibility"): thread
+            for thread in roster.get("threads", [])
+            if thread.get("responsibility")
+        }
+
+        return {
+            "generatedAt": utc_now_iso(),
+            "paths": {
+                "repoRoot": str(self.paths.repo_root),
+                "runtimeRoot": str(self.paths.runtime_root),
+                "helperInbox": str(self.paths.helper_handoff_inbox),
+            },
+            "overview": {
+                "watchdog": {
+                    "taskId": watchdog_status.get("taskId", ""),
+                    "status": watchdog_status.get("status", ""),
+                    "decision": watchdog_status.get("decision", ""),
+                    "queueDecision": watchdog_status.get("queueDecision", ""),
+                    "heartbeatAgeSeconds": watchdog_status.get("heartbeatAgeSeconds", 0),
+                    "heartbeatStale": watchdog_status.get("heartbeatStale", False),
+                    "queueEmpty": safe_get(watchdog_status, "queueReview", "queueEmpty", default=False),
+                    "reasons": safe_get(
+                        watchdog_status, "resourceGuardStatus", "reasons", default=[]
+                    ),
+                },
+                "helpers": {
+                    "handoffCount": helper_status.get("handoffCount", 0),
+                    "pendingAssignmentCount": helper_status.get("pendingAssignmentCount", 0),
+                    "staleAssignmentCount": helper_status.get("staleAssignmentCount", 0),
+                },
+                "scheduler": {
+                    "jobCount": scheduler_status.get("jobCount", 0),
+                    "openJobCount": scheduler_status.get("openJobCount", 0),
+                },
+                "gmail": {
+                    "running": gmail_status.get("running"),
+                    "skipReason": gmail_status.get("skipReason", ""),
+                    "updatedAt": gmail_status.get("updatedAt") or gmail_status.get("lastCycleAt", ""),
+                },
+            },
+            "threads": self._build_threads(roster, registry, helper_status),
+            "messageFlows": self._build_flows(helper_by_title, helper_by_responsibility),
+            "alerts": self._build_alerts(helper_status, scheduler_status, watchdog_status, gmail_status),
+        }
+
+    def _build_threads(
+        self, roster: dict[str, Any], registry: dict[str, Any], helper_status: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        helper_summary = {
+            item.get("responsibility"): item
+            for item in helper_status.get("helperSummary", [])
+            if item.get("responsibility")
+        }
+        threads: list[dict[str, Any]] = []
+
+        leader = roster.get("leader", {})
+        threads.append(
+            {
+                "kind": "main",
+                "displayName": leader.get("title", "main:orchestrator"),
+                "title": leader.get("title", "main:orchestrator"),
+                "role": leader.get("role", ""),
+                "stats": {},
+            }
+        )
+
+        for thread in roster.get("threads", []):
+            summary = helper_summary.get(thread.get("responsibility"), {})
+            threads.append(
+                {
+                    "kind": "helper",
+                    "displayName": thread.get("title", ""),
+                    "title": thread.get("title", ""),
+                    "role": thread.get("role", ""),
+                    "stats": {
+                        "responsibility": thread.get("responsibility", ""),
+                        "queued": summary.get("queued", 0),
+                        "running": summary.get("running", 0),
+                        "pending": summary.get("pending", 0),
+                        "oldestPendingMinutes": summary.get("oldestPendingMinutes", 0),
+                    },
+                }
+            )
+
+        for provider_name, provider in registry.get("providers", {}).items():
+            default_title = provider.get("defaultThreadTitle")
+            if default_title:
+                threads.append(
+                    {
+                        "kind": "provider",
+                        "displayName": default_title,
+                        "title": f"{provider_name}:default",
+                        "role": f"{provider_name} 기본 스레드",
+                        "stats": {"url": provider.get("defaultThreadUrl", "")},
+                    }
+                )
+            for route in provider.get("routes", []):
+                threads.append(
+                    {
+                        "kind": "provider-route",
+                        "displayName": route.get("title", ""),
+                        "title": f"{provider_name}:route",
+                        "role": f"{provider_name} 라우트 스레드",
+                        "stats": {
+                            "url": route.get("url", ""),
+                            "keywords": route.get("keywords", []),
+                        },
+                    }
+                )
+        return threads
+
+    def _build_flows(
+        self,
+        helper_by_title: dict[str, dict[str, Any]],
+        helper_by_responsibility: dict[str, dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        flows: list[dict[str, Any]] = []
+        files = sorted(
+            self.paths.helper_handoff_inbox.glob("*.json"),
+            key=lambda item: item.stat().st_mtime,
+            reverse=True,
+        )[:20]
+
+        for path in files:
+            handoff = read_json(path, {})
+            if not handoff:
+                continue
+            assignments = []
+            for assignment in handoff.get("assignments", []):
+                roster_thread = helper_by_responsibility.get(assignment.get("responsibility")) or helper_by_title.get(
+                    assignment.get("helperTitle")
+                )
+                assignments.append(
+                    {
+                        "assignmentId": assignment.get("assignmentId", ""),
+                        "helperTitle": roster_thread.get("title") if roster_thread else assignment.get("helperTitle", ""),
+                        "helperRole": roster_thread.get("role") if roster_thread else assignment.get("helperRole", ""),
+                        "helperThreadId": assignment.get("helperThreadId", ""),
+                        "status": assignment.get("status", ""),
+                        "step": assignment.get("step", ""),
+                        "updatedAt": assignment.get("updatedAt", ""),
+                        "requestPreview": trim_text(assignment.get("handoffPrompt", ""), 220),
+                        "responsePreview": trim_text(assignment.get("responseText", ""), 420),
+                    }
+                )
+
+            flows.append(
+                {
+                    "handoffId": handoff.get("handoffId", path.stem),
+                    "createdAt": handoff.get("createdAt", ""),
+                    "route": safe_get(handoff, "route", "route", default=""),
+                    "routeLabel": safe_get(handoff, "route", "routeLabel", default=""),
+                    "sourceTitle": safe_get(handoff, "source", "title", default=""),
+                    "sourceNotes": safe_get(handoff, "source", "notes", default=""),
+                    "taskPreview": trim_text(handoff.get("taskText", ""), 300),
+                    "path": str(path),
+                    "assignments": assignments,
+                }
+            )
+
+        flows.sort(
+            key=lambda item: max(
+                parse_timestamp(item.get("createdAt")),
+                *[parse_timestamp(entry.get("updatedAt")) for entry in item.get("assignments", [])],
+            ),
+            reverse=True,
+        )
+        return flows
+
+    def _build_alerts(
+        self,
+        helper_status: dict[str, Any],
+        scheduler_status: dict[str, Any],
+        watchdog_status: dict[str, Any],
+        gmail_status: dict[str, Any],
+    ) -> list[dict[str, str]]:
+        alerts: list[dict[str, str]] = []
+
+        stale = helper_status.get("staleAssignmentCount", 0)
+        if stale:
+            alerts.append(
+                {
+                    "level": "warn",
+                    "title": "stale helper assignment 존재",
+                    "detail": f"{stale}건의 stale helper assignment가 남아 있습니다.",
+                }
+            )
+
+        open_jobs = scheduler_status.get("openJobCount", 0)
+        if open_jobs:
+            alerts.append(
+                {
+                    "level": "info",
+                    "title": "중앙 스케줄러 open job 존재",
+                    "detail": f"현재 open job은 {open_jobs}건입니다.",
+                }
+            )
+
+        if watchdog_status.get("heartbeatStale"):
+            alerts.append(
+                {
+                    "level": "critical",
+                    "title": "watchdog heartbeat stale",
+                    "detail": "watchdog heartbeat가 stale 상태입니다.",
+                }
+            )
+
+        reasons = safe_get(watchdog_status, "resourceGuardStatus", "reasons", default=[])
+        if reasons:
+            alerts.append(
+                {
+                    "level": "info",
+                    "title": "자원 가드 보류 사유",
+                    "detail": ", ".join(reasons),
+                }
+            )
+
+        if gmail_status.get("skipReason"):
+            alerts.append(
+                {
+                    "level": "warn",
+                    "title": "Gmail 채널 cycle skip",
+                    "detail": gmail_status.get("skipReason", ""),
+                }
+            )
+
+        return alerts
+
+
+class ControlCenterHandler(SimpleHTTPRequestHandler):
+    static_root: Path
+    snapshot_builder: SnapshotBuilder
+
+    def translate_path(self, path: str) -> str:
+        parsed = urlparse(path).path
+        if parsed == "/":
+            parsed = "/index.html"
+        return str(self.static_root / parsed.lstrip("/"))
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/health":
+            payload = json.dumps({"ok": True, "generatedAt": utc_now_iso()}, ensure_ascii=False).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        if parsed.path == "/api/snapshot":
+            payload = json.dumps(self.snapshot_builder.build(), ensure_ascii=False).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        return super().do_GET()
+
+    def end_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def guess_type(self, path: str) -> str:
+        mime, _ = mimetypes.guess_type(path)
+        return mime or "application/octet-stream"
+
+
+def build_server(host: str, port: int, static_root: Path, snapshot_builder: SnapshotBuilder) -> ThreadingHTTPServer:
+    handler_cls = type(
+        "BoundControlCenterHandler",
+        (ControlCenterHandler,),
+        {"static_root": static_root, "snapshot_builder": snapshot_builder},
+    )
+    return ThreadingHTTPServer((host, port), handler_cls)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Codex Control Center")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--runtime-root", default=None)
+    args = parser.parse_args()
+
+    paths = RuntimePaths.detect(args.runtime_root)
+    static_root = Path(__file__).resolve().parents[1] / "static"
+    server = build_server(args.host, args.port, static_root, SnapshotBuilder(paths))
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "url": f"http://{args.host}:{args.port}",
+                "runtimeRoot": str(paths.runtime_root),
+                "generatedAt": utc_now_iso(),
+            },
+            ensure_ascii=False,
+        )
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/codex-control-center/start_control_center.ps1
+++ b/codex-control-center/start_control_center.ps1
@@ -1,0 +1,32 @@
+param(
+    [int]$Port = 8787,
+    [switch]$NoBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+$projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$serverPath = Join-Path $projectRoot "src\control_center_server.py"
+
+if (-not (Test-Path -LiteralPath $serverPath)) {
+    throw "Server script not found: $serverPath"
+}
+
+$process = Start-Process -FilePath "python" `
+    -ArgumentList @($serverPath, "--port", $Port) `
+    -WorkingDirectory $projectRoot `
+    -PassThru
+
+Start-Sleep -Seconds 2
+
+if (-not $NoBrowser) {
+    Start-Process "http://127.0.0.1:$Port"
+}
+
+[pscustomobject]@{
+    ok = $true
+    pid = $process.Id
+    port = $Port
+    url = "http://127.0.0.1:$Port"
+    projectRoot = $projectRoot
+} | ConvertTo-Json -Depth 4

--- a/codex-control-center/static/app.js
+++ b/codex-control-center/static/app.js
@@ -1,0 +1,161 @@
+const byId = (id) => document.getElementById(id);
+
+function makeStatItem(key, value) {
+  const wrapper = document.createElement("div");
+  const dt = document.createElement("dt");
+  const dd = document.createElement("dd");
+  dt.textContent = key;
+  dd.textContent = Array.isArray(value) ? value.join(", ") : String(value);
+  wrapper.append(dt, dd);
+  return wrapper;
+}
+
+function renderOverview(snapshot) {
+  const container = byId("overviewCards");
+  const template = byId("overviewCardTemplate");
+  container.innerHTML = "";
+
+  const cards = [
+    {
+      label: "Watchdog",
+      value: snapshot.overview.watchdog.status || "-",
+      detail: `task=${snapshot.overview.watchdog.taskId || "-"} / decision=${snapshot.overview.watchdog.decision || "-"}`,
+    },
+    {
+      label: "Queue",
+      value: snapshot.overview.watchdog.queueEmpty ? "비어 있음" : "작업 있음",
+      detail: `queueDecision=${snapshot.overview.watchdog.queueDecision || "-"}`,
+    },
+    {
+      label: "Helpers",
+      value: `${snapshot.overview.helpers.pendingAssignmentCount} pending`,
+      detail: `stale=${snapshot.overview.helpers.staleAssignmentCount}, handoff=${snapshot.overview.helpers.handoffCount}`,
+    },
+    {
+      label: "Scheduler",
+      value: `${snapshot.overview.scheduler.openJobCount} open`,
+      detail: `jobCount=${snapshot.overview.scheduler.jobCount}`,
+    },
+    {
+      label: "Gmail",
+      value: snapshot.overview.gmail.running ? "running" : "idle",
+      detail: snapshot.overview.gmail.skipReason || snapshot.overview.gmail.updatedAt || "-",
+    },
+  ];
+
+  for (const card of cards) {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.querySelector(".card-label").textContent = card.label;
+    node.querySelector(".card-value").textContent = card.value;
+    node.querySelector(".card-detail").textContent = card.detail;
+    container.appendChild(node);
+  }
+}
+
+function renderAlerts(snapshot) {
+  const container = byId("alerts");
+  container.innerHTML = "";
+
+  if (!snapshot.alerts.length) {
+    const empty = document.createElement("div");
+    empty.className = "alert";
+    empty.innerHTML = "<strong>현재 즉시 조치 경고 없음</strong><p>watchdog와 queue는 현재 읽기 기준으로 안정 상태입니다.</p>";
+    container.appendChild(empty);
+    return;
+  }
+
+  for (const alert of snapshot.alerts) {
+    const node = document.createElement("div");
+    node.className = `alert ${alert.level || ""}`;
+    node.innerHTML = `<strong>${alert.title}</strong><p>${alert.detail}</p>`;
+    container.appendChild(node);
+  }
+}
+
+function renderThreads(snapshot) {
+  const container = byId("threadGrid");
+  const template = byId("threadCardTemplate");
+  container.innerHTML = "";
+
+  for (const thread of snapshot.threads) {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.querySelector(".thread-kind").textContent = thread.kind;
+    node.querySelector(".thread-title").textContent = thread.displayName || thread.title;
+    node.querySelector(".thread-role").textContent = thread.role || "-";
+
+    const stats = node.querySelector(".thread-stats");
+    const entries = Object.entries(thread.stats || {});
+    if (!entries.length) {
+      stats.appendChild(makeStatItem("상태", "추가 통계 없음"));
+    } else {
+      for (const [key, value] of entries.slice(0, 6)) {
+        stats.appendChild(makeStatItem(key, value));
+      }
+    }
+    container.appendChild(node);
+  }
+}
+
+function renderFlows(snapshot) {
+  const container = byId("messageFlows");
+  const flowTemplate = byId("flowTemplate");
+  const assignmentTemplate = byId("assignmentTemplate");
+  container.innerHTML = "";
+
+  for (const flow of snapshot.messageFlows) {
+    const node = flowTemplate.content.firstElementChild.cloneNode(true);
+    node.querySelector(".flow-id").textContent = flow.handoffId;
+    node.querySelector(".flow-title").textContent = flow.sourceTitle || "최근 handoff";
+    node.querySelector(".flow-route").textContent = flow.routeLabel || flow.route || "route 없음";
+    node.querySelector(".flow-task").textContent = flow.taskPreview || "-";
+    node.querySelector(".flow-notes").textContent = flow.sourceNotes || flow.path;
+
+    const assignmentList = node.querySelector(".assignment-list");
+    for (const assignment of flow.assignments) {
+      const item = assignmentTemplate.content.firstElementChild.cloneNode(true);
+      item.querySelector(".assignment-helper").textContent = assignment.helperTitle || "helper";
+      item.querySelector(".assignment-status").textContent = `${assignment.status || "-"} / ${assignment.step || "-"}`;
+      item.querySelector(".assignment-role").textContent = assignment.helperRole || "-";
+      item.querySelector(".assignment-response").textContent = assignment.responsePreview || assignment.requestPreview || "-";
+      item.querySelector(".assignment-meta").textContent = `thread=${assignment.helperThreadId || "-"} / updatedAt=${assignment.updatedAt || "-"}`;
+      assignmentList.appendChild(item);
+    }
+
+    container.appendChild(node);
+  }
+}
+
+function renderPaths(snapshot) {
+  const container = byId("paths");
+  container.innerHTML = "";
+  for (const [label, path] of Object.entries(snapshot.paths || {})) {
+    const li = document.createElement("li");
+    li.textContent = `${label}: ${path}`;
+    container.appendChild(li);
+  }
+}
+
+async function loadSnapshot() {
+  const response = await fetch("/api/snapshot", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`snapshot request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function refresh() {
+  try {
+    const snapshot = await loadSnapshot();
+    byId("generatedAt").textContent = snapshot.generatedAt;
+    renderOverview(snapshot);
+    renderAlerts(snapshot);
+    renderThreads(snapshot);
+    renderFlows(snapshot);
+    renderPaths(snapshot);
+  } catch (error) {
+    byId("alerts").innerHTML = `<div class="alert critical"><strong>데이터 로드 실패</strong><p>${error.message}</p></div>`;
+  }
+}
+
+refresh();
+setInterval(refresh, 5000);

--- a/codex-control-center/static/index.html
+++ b/codex-control-center/static/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Codex Control Center</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div class="shell">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Windows Orchestration Monitor</p>
+        <h1>Codex Control Center</h1>
+        <p class="subtitle">메인 오케스트레이터, 서브 스레드, 메시지 흐름, watchdog, 중앙 스케줄러를 한 화면에서 봅니다.</p>
+      </div>
+      <div class="hero-meta">
+        <div class="hero-badge">
+          <span>마지막 갱신</span>
+          <strong id="generatedAt">-</strong>
+        </div>
+        <div class="hero-badge">
+          <span>자동 새로고침</span>
+          <strong>5초</strong>
+        </div>
+      </div>
+    </header>
+
+    <section id="overviewCards" class="overview-grid"></section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>경고와 주의</h2>
+      </div>
+      <div id="alerts" class="alerts"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>등록된 스레드와 역할</h2>
+      </div>
+      <div id="threadGrid" class="thread-grid"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>최근 메시지 흐름</h2>
+        <p>최근 20개의 handoff와 각 helper 응답을 타임라인처럼 보여줍니다.</p>
+      </div>
+      <div id="messageFlows" class="message-flows"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>원본 경로</h2>
+      </div>
+      <ul id="paths" class="path-list"></ul>
+    </section>
+  </div>
+
+  <template id="overviewCardTemplate">
+    <article class="overview-card">
+      <p class="card-label"></p>
+      <strong class="card-value"></strong>
+      <p class="card-detail"></p>
+    </article>
+  </template>
+
+  <template id="threadCardTemplate">
+    <article class="thread-card">
+      <div class="thread-head">
+        <span class="thread-kind"></span>
+        <h3 class="thread-title"></h3>
+      </div>
+      <p class="thread-role"></p>
+      <dl class="thread-stats"></dl>
+    </article>
+  </template>
+
+  <template id="flowTemplate">
+    <article class="flow-card">
+      <div class="flow-meta">
+        <div>
+          <p class="flow-id"></p>
+          <h3 class="flow-title"></h3>
+        </div>
+        <div class="flow-route"></div>
+      </div>
+      <p class="flow-task"></p>
+      <p class="flow-notes"></p>
+      <div class="assignment-list"></div>
+    </article>
+  </template>
+
+  <template id="assignmentTemplate">
+    <div class="assignment">
+      <div class="assignment-head">
+        <strong class="assignment-helper"></strong>
+        <span class="assignment-status"></span>
+      </div>
+      <p class="assignment-role"></p>
+      <p class="assignment-response"></p>
+      <p class="assignment-meta"></p>
+    </div>
+  </template>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/codex-control-center/static/styles.css
+++ b/codex-control-center/static/styles.css
@@ -1,0 +1,296 @@
+:root {
+  --bg: #0f141b;
+  --panel: #151d27;
+  --panel-strong: #1b2633;
+  --line: #2a3b4d;
+  --text: #eef4fb;
+  --muted: #9bb0c3;
+  --accent: #69d2b4;
+  --accent-strong: #f3b44f;
+  --warn: #ff8a6b;
+  --shadow: 0 22px 50px rgba(0, 0, 0, 0.24);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  color: var(--text);
+  font-family: "Segoe UI", "Malgun Gothic", sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(105, 210, 180, 0.14), transparent 30%),
+    radial-gradient(circle at top right, rgba(243, 180, 79, 0.12), transparent 25%),
+    linear-gradient(180deg, #0b1118 0%, #111822 45%, #0f141b 100%);
+}
+
+.shell {
+  max-width: 1520px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.card-label,
+.thread-kind,
+.flow-id,
+.assignment-meta,
+.panel-header p,
+.path-list {
+  color: var(--muted);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 54px);
+}
+
+.subtitle {
+  margin: 10px 0 0;
+  color: var(--muted);
+  max-width: 760px;
+}
+
+.hero-meta {
+  display: grid;
+  gap: 12px;
+  min-width: 220px;
+}
+
+.hero-badge,
+.overview-card,
+.panel,
+.thread-card,
+.flow-card {
+  background: linear-gradient(180deg, rgba(27, 38, 51, 0.95), rgba(19, 27, 37, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow);
+}
+
+.hero-badge {
+  border-radius: 16px;
+  padding: 14px 16px;
+}
+
+.hero-badge strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 18px;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.overview-card {
+  border-radius: 18px;
+  padding: 18px;
+}
+
+.card-label {
+  margin: 0 0 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.card-value {
+  display: block;
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.card-detail {
+  margin: 0;
+}
+
+.panel {
+  border-radius: 24px;
+  padding: 22px;
+  margin-bottom: 22px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+  margin-bottom: 16px;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.alerts,
+.message-flows {
+  display: grid;
+  gap: 12px;
+}
+
+.alert {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.alert.warn {
+  border-color: rgba(255, 138, 107, 0.5);
+}
+
+.alert.critical {
+  border-color: rgba(255, 138, 107, 0.95);
+  background: rgba(255, 138, 107, 0.08);
+}
+
+.thread-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.thread-card {
+  border-radius: 18px;
+  padding: 18px;
+}
+
+.thread-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.thread-kind {
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(105, 210, 180, 0.14);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.thread-title,
+.flow-title {
+  margin: 0;
+}
+
+.thread-role {
+  margin: 0 0 14px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.thread-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 12px;
+  margin: 0;
+}
+
+.thread-stats div {
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.thread-stats dt {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.thread-stats dd {
+  margin: 6px 0 0;
+  font-weight: 700;
+}
+
+.flow-card {
+  border-radius: 18px;
+  padding: 18px;
+}
+
+.flow-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+
+.flow-route {
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: rgba(243, 180, 79, 0.14);
+  color: var(--accent-strong);
+  white-space: nowrap;
+}
+
+.flow-task,
+.flow-notes,
+.assignment-response,
+.assignment-role {
+  margin: 0 0 10px;
+  line-height: 1.6;
+}
+
+.assignment-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.assignment {
+  border-radius: 14px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.assignment-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.assignment-status {
+  color: var(--accent);
+}
+
+.path-list {
+  margin: 0;
+  padding-left: 18px;
+  line-height: 1.8;
+  word-break: break-all;
+}
+
+@media (max-width: 920px) {
+  .hero,
+  .panel-header,
+  .flow-meta,
+  .assignment-head {
+    flex-direction: column;
+  }
+
+  .thread-stats {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Windows-friendly orchestration dashboard under `codex-control-center`
- surface main orchestrator, helper threads, recent handoff message flows, watchdog, scheduler, and Gmail status
- include PowerShell/CMD launchers and runtime root autodetection for both repo layouts

## Verification
- python -m py_compile codex-control-center/src/control_center_server.py
- start_control_center.ps1 -Port 8788 -NoBrowser
- GET /api/health
- GET /api/snapshot